### PR TITLE
Fix email truncation for emails up to 30 characters (e.g., 42 Porto emails)

### DIFF
--- a/plugin/stdheader.vim
+++ b/plugin/stdheader.vim
@@ -59,7 +59,12 @@ endfunction
 function! s:textline(left, right)
 	let l:left = strpart(a:left, 0, s:length - s:margin * 2 - strlen(a:right))
 
-	return s:start . repeat(' ', s:margin - strlen(s:start)) . l:left . repeat(' ', s:length - s:margin * 2 - strlen(l:left) - strlen(a:right)) . a:right . repeat(' ', s:margin - strlen(s:end)) . s:end
+	let l:spaces = s:length - s:margin * 2 - strlen(l:left) - strlen(a:right)
+	if l:spaces < 0
+		let l:spaces = 0
+	endif
+
+	return s:start . repeat(' ', s:margin - strlen(s:start)) . l:left . repeat(' ', l:spaces) . a:right . repeat(' ', s:margin - strlen(s:end)) . s:end
 endfunction
 
 function! s:line(n)


### PR DESCRIPTION
This PR fixes an issue where emails with up to 30 characters, such as those from 42 Porto (m1234567@student.42porto.com , 28 chars), were being incorrectly truncated, leaving the ending as "co" instead of "com>".
