### PR TITLE
Automatically fix merge conflicts created by the 42 Header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Inside the **42 clusters** you can easily run:
 [@alexandregv](https://github.com/alexandregv) - contributor  
 [@mjacq42](https://github.com/mjacq42) - contributor  
 [@sungmcho](https://github.com/lordtomi0325) - contributor  
+[@fclivaz42](https://github.com/fclivaz42) - contributor  
 
 ### **License**
 

--- a/plugin/stdheader.vim
+++ b/plugin/stdheader.vim
@@ -167,6 +167,7 @@ function! s:fix_merge_conflict()
 			call setline(l:line, s:line(l:line))
 			let l:line = l:line + 1
 		endwhile
+		echo "42header conflicts automatically resolved!"
 	exe ":12,15d"
 
 	" fix conflict on both 'Created:' and 'Updated:' (unlikely, but useful in case)
@@ -176,6 +177,7 @@ function! s:fix_merge_conflict()
 			call setline(l:line, s:line(l:line))
 			let l:line = l:line + 1
 		endwhile
+		echo "42header conflicts automatically resolved!"
 	exe ":12,16d"
 	endif
 endfunction

--- a/plugin/stdheader.vim
+++ b/plugin/stdheader.vim
@@ -15,7 +15,7 @@ let s:length	= 80
 let s:margin	= 5
 
 let s:types		= {
-			\'\.c$\|\.h$\|\.cc$\|\.hh$\|\.cpp$\|\.hpp$\|\.tpp$\|\.ipp$\|\.cxx$\|\.go$\|\.rs$\|\.php$\|\.py$\|\.java$\|\.kt$\|\.kts$':
+			\'\.c$\|\.h$\|\.cc$\|\.hh$\|\.cpp$\|\.hpp$\|\.tpp$\|\.ipp$\|\.cxx$\|\.go$\|\.rs$\|\.php$\|\.java$\|\.kt$\|\.kts$':
 			\['/*', '*/', '*'],
 			\'\.htm$\|\.html$\|\.xml$':
 			\['<!--', '-->', '*'],
@@ -145,7 +145,32 @@ function! s:stdheader()
 	endif
 endfunction
 
+function! s:fix_merge_conflict()
+	call s:filetype()
+	let l:checkline = s:start . repeat(' ', s:margin - strlen(s:start)) . "Updated: "
+
+	" fix conflict on 'Updated:' line
+	if getline(9) =~ "<<<<<<<" && getline(11) =~ "=======" && getline(13) =~ ">>>>>>>" && getline(10) =~ l:checkline
+		let l:line = 9
+		while l:line < 12
+			call setline(l:line, s:line(l:line))
+			let l:line = l:line + 1
+		endwhile
+	exe ":12,15d"
+
+	" fix conflict on both 'Created:' and 'Updated:' (unlikely, but useful in case)
+	elseif getline(8) =~ "<<<<<<<" && getline(11) =~ "=======" && getline(14) =~ ">>>>>>>" && getline(10) =~ l:checkline
+		let l:line = 8
+		while l:line < 12
+			call setline(l:line, s:line(l:line))
+			let l:line = l:line + 1
+		endwhile
+	exe ":12,16d"
+	endif
+endfunction
+
 " Bind command and shortcut
 command! Stdheader call s:stdheader ()
 map <F1> :Stdheader<CR>
 autocmd BufWritePre * call s:update ()
+autocmd BufReadPost * call s:fix_merge_conflict ()


### PR DESCRIPTION
This merge request aims to fix an issue when multiple people are working on the same file: the header changes the `Updated:` line on each users file, thus creating merge conflicts. This change aims to automatically fix this issue by removing the offending lines as well as the affected version control conflict markers on opening a file (after checking it is, in fact, a 42 Header).

This also aims to fix an oversight causing issue #17 which #18 aimed to solve as well.