### PR TITLE
added augroup to fix the bug in vimrc sourcing, and to disable the pl…

### DIFF
--- a/plugin/stdheader.vim
+++ b/plugin/stdheader.vim
@@ -146,6 +146,11 @@ function! s:stdheader()
 endfunction
 
 " Bind command and shortcut
+
 command! Stdheader call s:stdheader ()
 map <F1> :Stdheader<CR>
-autocmd BufWritePre * call s:update ()
+
+augroup stdheader
+	autocmd!
+	autocmd BufWritePre * call s:update ()
+augroup END


### PR DESCRIPTION
Currently, it's impossible to deactivate the plugin (if the plugin is in ROOT access),
and for a correct script it must surround its autocommands with augroup to avoid duplication and conflicts when resourcing the file.